### PR TITLE
chore: experiment webpack client manifest for ssr

### DIFF
--- a/webpack-react-ssr/biome.json
+++ b/webpack-react-ssr/biome.json
@@ -2,8 +2,7 @@
 	"$schema": "https://biomejs.dev/schemas/1.8.1/schema.json",
 	"vcs": {
 		"enabled": true,
-		"clientKind": "git",
-		"useIgnoreFile": true
+		"clientKind": "git"
 	},
 	"linter": { "enabled": false }
 }

--- a/webpack-react-ssr/package.json
+++ b/webpack-react-ssr/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "webpack-react-spa",
+	"name": "webpack-react-ssr",
 	"private": true,
 	"version": "0.0.0",
 	"type": "module",
@@ -15,6 +15,7 @@
 		"vc-release-staging": "vercel deploy --prebuilt"
 	},
 	"dependencies": {
+		"@hiogawa/utils": "^1.7.0",
 		"react": "19.0.0-rc-dfd30974ab-20240613",
 		"react-dom": "19.0.0-rc-dfd30974ab-20240613"
 	},

--- a/webpack-react-ssr/package.json
+++ b/webpack-react-ssr/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"dev": "webpack serve",
+		"dev-webpack": "node --watch-path webpack.config.js --watch-preserve-output node_modules/webpack/bin/webpack.js serve",
 		"build": "webpack && cp -r public/. dist/client",
 		"preview": "vite preview",
 		"lint": "biome check --write .",

--- a/webpack-react-ssr/pnpm-lock.yaml
+++ b/webpack-react-ssr/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hiogawa/utils':
+        specifier: ^1.7.0
+        version: 1.7.0
       react:
         specifier: 19.0.0-rc-dfd30974ab-20240613
         version: 19.0.0-rc-dfd30974ab-20240613
@@ -251,6 +254,9 @@ packages:
 
   '@hiogawa/utils-node@0.0.1':
     resolution: {integrity: sha512-vEir6KhApTlPPT+0wX85wglFgZjxG/WZGjWGahSR7+ltNkpY0OpmxozbF5sLodYgXPObTK8cKgsQ4nzFLtZQ8g==}
+
+  '@hiogawa/utils@1.7.0':
+    resolution: {integrity: sha512-ghiEFWBR1NENoHn+lSuW7liicTIzVPN+8Srm5UedCTw43gus0mlse6Wp2lz6GmbOXJ/CalMPp/0Tz2X8tajkAg==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -1996,6 +2002,8 @@ snapshots:
     optional: true
 
   '@hiogawa/utils-node@0.0.1': {}
+
+  '@hiogawa/utils@1.7.0': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/webpack-react-ssr/src/entry-server.tsx
+++ b/webpack-react-ssr/src/entry-server.tsx
@@ -11,10 +11,11 @@ export type Manifest = {
 
 export async function handler(_request: Request, manifest: Manifest) {
 	const clientEntry = manifest.clientStats.assetsByChunkName?.["client"];
-	tinyassert(clientEntry?.length === 1);
+	tinyassert(clientEntry);
 
 	const htmlStream = await ReactDOMServer.renderToReadableStream(<Root />, {
-		bootstrapScripts: clientEntry,
+		// exclude hot-update.js during dev?
+		bootstrapScripts: clientEntry.slice(0, 1),
 	});
 	return new Response(htmlStream, {
 		headers: {

--- a/webpack-react-ssr/src/entry-server.tsx
+++ b/webpack-react-ssr/src/entry-server.tsx
@@ -1,11 +1,20 @@
+import { tinyassert } from "@hiogawa/utils";
 import ReactDOMServer from "react-dom/server.edge";
+import type { StatsCompilation } from "webpack";
 import { App } from "./App";
 import css from "./index.css?raw";
 
-export async function handler(_request: Request) {
+// TODO: virtual module?
+export type Manifest = {
+	stats: StatsCompilation;
+};
+
+export async function handler(_request: Request, manifest: Manifest) {
+	const clientStats = manifest.stats.children?.find((s) => s.name === "client");
+	tinyassert(clientStats?.assetsByChunkName);
+
 	const htmlStream = await ReactDOMServer.renderToReadableStream(<Root />, {
-		// TODO: hashed assets for prod
-		bootstrapScripts: ["/client.js"],
+		bootstrapScripts: clientStats.assetsByChunkName["client"],
 	});
 	return new Response(htmlStream, {
 		headers: {

--- a/webpack-react-ssr/src/entry-server.tsx
+++ b/webpack-react-ssr/src/entry-server.tsx
@@ -6,15 +6,15 @@ import css from "./index.css?raw";
 
 // TODO: virtual module?
 export type Manifest = {
-	stats: StatsCompilation;
+	clientStats: StatsCompilation;
 };
 
 export async function handler(_request: Request, manifest: Manifest) {
-	const clientStats = manifest.stats.children?.find((s) => s.name === "client");
-	tinyassert(clientStats?.assetsByChunkName);
+	const clientEntry = manifest.clientStats.assetsByChunkName?.["client"];
+	tinyassert(clientEntry?.length === 1);
 
 	const htmlStream = await ReactDOMServer.renderToReadableStream(<Root />, {
-		bootstrapScripts: clientStats.assetsByChunkName["client"],
+		bootstrapScripts: clientEntry,
 	});
 	return new Response(htmlStream, {
 		headers: {

--- a/webpack-react-ssr/src/types/define.d.ts
+++ b/webpack-react-ssr/src/types/define.d.ts
@@ -1,0 +1,11 @@
+interface ImportMeta {
+	readonly env: {
+		DEV: boolean;
+		SSR: boolean;
+	};
+}
+
+declare let __define: {
+	DEV: boolean;
+	SSR: boolean;
+};

--- a/webpack-react-ssr/webpack.config.js
+++ b/webpack-react-ssr/webpack.config.js
@@ -52,6 +52,7 @@ export default function (env, _argv) {
 	const serverConfig = {
 		...commonConfig,
 		name: "server",
+		dependencies: ["client"],
 		target: "node20",
 		// TODO: https://webpack.js.org/configuration/externals
 		externals: {},
@@ -94,23 +95,15 @@ export default function (env, _argv) {
 								name: "dev-ssr",
 								// @ts-ignore
 								middleware: (req, res, next) => {
-									// TODO: how to pass it to server runtime?
+									// TODO: how to pass on prod?
 									/** @type {import("webpack").MultiStats} */
 									const stats = res.locals.webpack.devMiddleware.stats;
 									const statsJson = stats.toJson();
-									// console.log(statsJson)
-
-									const clientStats = statsJson.children?.find(
-										(s) => s.name === "client",
-									);
-									0 &&
-										console.log(JSON.stringify(clientStats?.assets, null, 2));
-									// 0 && console.log(statsJson);
 
 									/** @type {import("./src/entry-server")} */
 									const mod = require(serverPath);
 									const nodeHandler = webToNodeHandler((request) =>
-										mod.handler(request),
+										mod.handler(request, { stats: statsJson }),
 									);
 									nodeHandler(req, res, next);
 								},
@@ -142,7 +135,8 @@ export default function (env, _argv) {
 		},
 		output: {
 			path: path.resolve("./dist/client"),
-			filename: env.WEBPACK_BUILD ? "[name].[contenthash:8].js" : "[name].js",
+			filename:
+				1 || env.WEBPACK_BUILD ? "[name].[contenthash:8].js" : "[name].js",
 			clean: true,
 		},
 	};

--- a/webpack-react-ssr/webpack.config.js
+++ b/webpack-react-ssr/webpack.config.js
@@ -136,8 +136,7 @@ export default function (env, _argv) {
 		},
 		output: {
 			path: path.resolve("./dist/client"),
-			filename:
-				1 || env.WEBPACK_BUILD ? "[name].[contenthash:8].js" : "[name].js",
+			filename: env.WEBPACK_BUILD ? "[name].[contenthash:8].js" : "[name].js",
 			clean: true,
 		},
 		plugins: [


### PR DESCRIPTION
- [x] start with external file like webpack manifest plugin
  - just emitting on client build is enough
- [x] dev / build runtime switch?
  - we can define on our own `__define.DEV: boolean`
- [ ] "virtual module" with custom loader?
