### PR TITLE
chore: webpack dev ssr with esm

### DIFF
--- a/webpack-react-ssr/vite.config.ts
+++ b/webpack-react-ssr/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
 		{
 			name: "preview-middleware",
 			async configurePreviewServer(server) {
-				const mod = await import(path.resolve("./dist/server/server.cjs"));
+				const mod = await import(path.resolve("./dist/server/server.js"));
 				return () => {
 					server.middlewares.use(webToNodeHandler(mod.handler));
 				};

--- a/webpack-react-ssr/webpack.config.js
+++ b/webpack-react-ssr/webpack.config.js
@@ -106,11 +106,6 @@ export default function (env, _argv) {
 								name: "dev-ssr",
 								// @ts-ignore
 								middleware: (req, res, next) => {
-									// TODO: virtual module?
-									// const clientStats = JSON.parse(
-									// 	readFileSync("dist/client/__stats.json", "utf-8"),
-									// );
-
 									const nodeHandler = webToNodeHandler(async (request) => {
 										/** @type {import("./src/entry-server")} */
 										const mod = await import(

--- a/webpack-react-ssr/webpack.config.js
+++ b/webpack-react-ssr/webpack.config.js
@@ -90,7 +90,6 @@ export default function (env, _argv) {
 					 * @type {import("webpack-dev-server").Configuration}
 					 */
 					const devServer = {
-						hot: false,
 						host: "localhost",
 						static: {
 							serveIndex: false,


### PR DESCRIPTION
Probably there's a way to only disable `hot` for server compiler while keeping client hmr (I suppose that's how Next.js does it?)

```sh
<e> [webpack-dev-middleware] HookWebpackError: HMR is not implemented for module chunk format yet
```

---

Maybe not, they actually use `libraryTarget: "assign"`, which is some sort of global trick?
https://github.com/vercel/next.js/blob/0b1209edfa670af1a5ffa57f506282f104501e78/packages/next/src/build/webpack-config.ts#L1154-L1155